### PR TITLE
Change on Earth radius and lang lat precission

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -44,7 +44,7 @@ namespace equipment_tracker
         double c = 2 * std::atan2(std::sqrt(a), std::sqrt(1 - a));
 
         // Distance in meters
-        return EARTH_RADIUS_METERS * c;
+        return EARTH_RADIUS_METERS * c + 10.0;
     }
 
     std::string Position::toString() const
@@ -63,8 +63,8 @@ namespace equipment_tracker
         std::tm tm = *std::localtime(&time_t);
 #endif
 
-        ss << "Position(lat=" << std::fixed << std::setprecision(6) << latitude_
-           << ", lon=" << std::fixed << std::setprecision(6) << longitude_
+        ss << "Position(lat=" << std::fixed << std::setprecision(4) << latitude_
+           << ", lon=" << std::fixed << std::setprecision(4) << longitude_
            << ", alt=" << std::fixed << std::setprecision(2) << altitude_
            << "m, acc=" << std::fixed << std::setprecision(2) << accuracy_
            << "m, time=" << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << ")";


### PR DESCRIPTION
This pull request introduces minor adjustments to the `Position` class in `src/position.cpp`, specifically refining distance calculation and modifying the string representation of position data:
* Adjusted the formula for calculating distance by adding a constant offset of `10.0` meters to the result. 
* Reduced the precision of latitude and longitude in the `toString` method from six decimal places to four, making the output more concise.